### PR TITLE
Remove Bitquery price source and rely on Moralis

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ yarn start
 - `TELEGRAM_GROUP_ID` – numeric chat ID to restrict bot interaction.
 - `RPC_URL` – Solana RPC endpoint.
 - `WEBSOCKET_URL` – websocket endpoint for the RPC provider.
-- `FALCONHIT_API_KEY`, `MORALIS_API_KEY`, `BITQUERY_V2_TOKEN`, `BITQUERY_V1_TOKEN` – API keys for price data providers.
+- `FALCONHIT_API_KEY`, `MORALIS_API_KEY` – API keys for pool data and token prices.
 
 ### Local Settings (`src/config.ts`)
 - `solanaWallets` – array of base58‑encoded private keys used for trading.
@@ -56,7 +56,7 @@ yarn start
 
 - Only valid Solana token addresses are accepted.
 - Swaps are executed on Raydium using the configured wallets.
-- Price data is fetched from Bitquery with Moralis fallback.
+- Price data is fetched from Moralis.
 - Logs are written to the `logs/` directory.
 
 ## License

--- a/dist/util/helper.js
+++ b/dist/util/helper.js
@@ -3,11 +3,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getTokenBalance = exports.getTokenAccountByOwnerAndMint = exports.convertAsSignal = exports.getSolanaTokenPriceBitquery = exports.getSolanaTokenPrice = exports.MoralisStart = exports.Delay = exports.getRandomArbitrary = exports.verifyAddress = void 0;
+exports.getTokenBalance = exports.getTokenAccountByOwnerAndMint = exports.convertAsSignal = exports.getSolanaTokenPrice = exports.MoralisStart = exports.Delay = exports.getRandomArbitrary = exports.verifyAddress = void 0;
 const web3_js_1 = require("@solana/web3.js");
 const types_1 = require("./types");
 const moralis_1 = __importDefault(require("moralis"));
-const axios_1 = __importDefault(require("axios"));
 const dotenv_1 = __importDefault(require("dotenv"));
 const logger_1 = require("./logger");
 dotenv_1.default.config();
@@ -15,9 +14,6 @@ const config_1 = require("../config");
 const anchor_1 = require("@coral-xyz/anchor");
 const bs58_1 = __importDefault(require("bs58"));
 const MORALIS_API_KEY = process.env.MORALIS_API_KEY;
-const BITQUERY_V2_TOKEN = process.env.BITQUERY_V2_TOKEN;
-const BITQUERY_V1_TOKEN = process.env.BITQUERY_V1_TOKEN;
-const PRICE_PROVIDER = (process.env.PRICE_PROVIDER || 'auto').toLowerCase();
 const verifySolanaAddress = (address) => {
     if (address.length < 32 || address.length > 44) {
         return false;
@@ -64,77 +60,11 @@ const getSolanaTokenPrice = async (address) => {
             (0, logger_1.childLogger)(logger_1.tradeLogger, 'Price').error("solana token price", err);
         }
     }
-};
-exports.getSolanaTokenPrice = getSolanaTokenPrice;
-const getSolanaTokenPriceBitquery = async (address) => {
-    var _a, _b, _c, _d, _e, _f, _g, _h;
-    // Allow opting out of Bitquery entirely
-    if (PRICE_PROVIDER === 'moralis') {
-        const m = await (0, exports.getSolanaTokenPrice)(address);
-        return { usdPrice: m === null || m === void 0 ? void 0 : m.usdPrice };
-    }
-    await (0, exports.Delay)(200);
-    (0, logger_1.childLogger)(logger_1.tradeLogger, 'Price').debug("token mint address", { address });
-    const query = `{
-      Solana {
-        DEXTradeByTokens(
-          where: {Trade: {Currency: {MintAddress: {is: "${address}"}}}}
-          orderBy: {descending: Trade_Side_Currency_Decimals}
-          limit: {count: 1}
-        ) { Trade { PriceInUSD } }
-      }
-    }`;
-    const useEap = Boolean(BITQUERY_V1_TOKEN && BITQUERY_V2_TOKEN && BITQUERY_V1_TOKEN !== '...' && BITQUERY_V2_TOKEN !== '...');
-    const url = useEap ? 'https://streaming.bitquery.io/eap' : 'https://graphql.bitquery.io';
-    const headers = {
-        'Content-Type': 'application/json',
-    };
-    if (BITQUERY_V1_TOKEN && BITQUERY_V1_TOKEN !== '...')
-        headers['X-API-KEY'] = BITQUERY_V1_TOKEN;
-    if (useEap)
-        headers['Authorization'] = `Bearer ${BITQUERY_V2_TOKEN}`;
-    const config = {
-        method: 'post',
-        maxBodyLength: Infinity,
-        url,
-        headers,
-        data: JSON.stringify({ query, variables: '{}' }),
-    };
-    for (let i = 0; i < 5; i++) {
-        try {
-            const response = await axios_1.default.request(config);
-            (0, logger_1.childLogger)(logger_1.tradeLogger, 'Price').debug("bitquery response", response.data);
-            const price = (_f = (_e = (_d = (_c = (_b = (_a = response === null || response === void 0 ? void 0 : response.data) === null || _a === void 0 ? void 0 : _a.data) === null || _b === void 0 ? void 0 : _b.Solana) === null || _c === void 0 ? void 0 : _c.DEXTradeByTokens) === null || _d === void 0 ? void 0 : _d[0]) === null || _e === void 0 ? void 0 : _e.Trade) === null || _f === void 0 ? void 0 : _f.PriceInUSD;
-            if (price != null) {
-                return { usdPrice: price };
-            }
-            else {
-                (0, logger_1.childLogger)(logger_1.tradeLogger, 'Price').warn("Bitquery: no DEX price for token", { address });
-            }
-        }
-        catch (err) {
-            const status = (_g = err === null || err === void 0 ? void 0 : err.response) === null || _g === void 0 ? void 0 : _g.status;
-            const msg = ((_h = err === null || err === void 0 ? void 0 : err.response) === null || _h === void 0 ? void 0 : _h.data) || (err === null || err === void 0 ? void 0 : err.message);
-            (0, logger_1.childLogger)(logger_1.tradeLogger, 'Price').warn("Bitquery price fetch error", { address, status, msg });
-        }
-        await (0, exports.Delay)(1000);
-    }
-    // Fallback to Moralis if Bitquery failed
-    try {
-        const m = await (0, exports.getSolanaTokenPrice)(address);
-        const usdPrice = m === null || m === void 0 ? void 0 : m.usdPrice;
-        if (usdPrice != null) {
-            (0, logger_1.childLogger)(logger_1.tradeLogger, 'Price').info("Fallback: Moralis price used", { address, usdPrice });
-            return { usdPrice };
-        }
-    }
-    catch (err) {
-        (0, logger_1.childLogger)(logger_1.tradeLogger, 'Price').warn("Moralis fallback failed", { address });
-    }
-    // Final: return a shaped object to avoid spread errors upstream
+    // Shaped return to avoid spread errors if price lookup fails
     return { usdPrice: undefined };
 };
-exports.getSolanaTokenPriceBitquery = getSolanaTokenPriceBitquery;
+exports.getSolanaTokenPrice = getSolanaTokenPrice;
+// Bitquery support removed; Moralis is the sole price provider
 const convertAsSignal = async (histories, solana = false) => {
     try {
         const data = histories.map((item) => {
@@ -148,8 +78,9 @@ const convertAsSignal = async (histories, solana = false) => {
         const newPrice = [];
         let priceResult = [];
         for (let i = 0; i < uniqueData.length; i++) {
+            const priceData = await (0, exports.getSolanaTokenPrice)(uniqueData[i].address);
             priceResult[i] = {
-                ...await (0, exports.getSolanaTokenPriceBitquery)(uniqueData[i].address),
+                usdPrice: priceData === null || priceData === void 0 ? void 0 : priceData.usdPrice,
                 tokenAddress: uniqueData[i].address
             };
         }

--- a/src/util/helper.ts
+++ b/src/util/helper.ts
@@ -1,7 +1,6 @@
 import { Keypair, PublicKey } from "@solana/web3.js"
 import { addressType, signal } from "./types";
 import Moralis from "moralis";
-import axios from 'axios';
 import dotenv from "dotenv";
 import { appLogger, tradeLogger, childLogger } from "./logger";
 dotenv.config();
@@ -11,9 +10,6 @@ import { Wallet } from "@coral-xyz/anchor";
 import bs58 from "bs58";
 
 const MORALIS_API_KEY = process.env.MORALIS_API_KEY;
-const BITQUERY_V2_TOKEN = process.env.BITQUERY_V2_TOKEN;
-const BITQUERY_V1_TOKEN = process.env.BITQUERY_V1_TOKEN;
-const PRICE_PROVIDER = (process.env.PRICE_PROVIDER || 'auto').toLowerCase();
 
 
 
@@ -60,76 +56,11 @@ export const getSolanaTokenPrice = async (address: string) => {
             childLogger(tradeLogger, 'Price').error("solana token price", err);
         }
     }
-}
-
-export const getSolanaTokenPriceBitquery = async (address: string) => {
-    // Allow opting out of Bitquery entirely
-    if (PRICE_PROVIDER === 'moralis') {
-      const m = await getSolanaTokenPrice(address);
-      return { usdPrice: (m as any)?.usdPrice };
-    }
-    await Delay(200);
-    childLogger(tradeLogger, 'Price').debug("token mint address", { address })
-
-    const query = `{
-      Solana {
-        DEXTradeByTokens(
-          where: {Trade: {Currency: {MintAddress: {is: "${address}"}}}}
-          orderBy: {descending: Trade_Side_Currency_Decimals}
-          limit: {count: 1}
-        ) { Trade { PriceInUSD } }
-      }
-    }`;
-
-    const useEap = Boolean(BITQUERY_V1_TOKEN && BITQUERY_V2_TOKEN && BITQUERY_V1_TOKEN !== '...' && BITQUERY_V2_TOKEN !== '...')
-    const url = useEap ? 'https://streaming.bitquery.io/eap' : 'https://graphql.bitquery.io';
-    const headers: any = {
-      'Content-Type': 'application/json',
-    };
-    if (BITQUERY_V1_TOKEN && BITQUERY_V1_TOKEN !== '...') headers['X-API-KEY'] = BITQUERY_V1_TOKEN;
-    if (useEap) headers['Authorization'] = `Bearer ${BITQUERY_V2_TOKEN}`;
-
-    const config = {
-      method: 'post' as const,
-      maxBodyLength: Infinity,
-      url,
-      headers,
-      data: JSON.stringify({ query, variables: '{}' }),
-    };
-
-    for (let i = 0; i < 5; i++) {
-      try {
-        const response = await axios.request(config);
-        childLogger(tradeLogger, 'Price').debug("bitquery response", response.data);
-        const price = response?.data?.data?.Solana?.DEXTradeByTokens?.[0]?.Trade?.PriceInUSD;
-        if (price != null) {
-          return { usdPrice: price };
-        } else {
-          childLogger(tradeLogger, 'Price').warn("Bitquery: no DEX price for token", { address });
-        }
-      } catch (err: any) {
-        const status = err?.response?.status;
-        const msg = err?.response?.data || err?.message;
-        childLogger(tradeLogger, 'Price').warn("Bitquery price fetch error", { address, status, msg });
-      }
-      await Delay(1000);
-    }
-
-    // Fallback to Moralis if Bitquery failed
-    try {
-      const m = await getSolanaTokenPrice(address);
-      const usdPrice = (m as any)?.usdPrice;
-      if (usdPrice != null) {
-        childLogger(tradeLogger, 'Price').info("Fallback: Moralis price used", { address, usdPrice });
-        return { usdPrice };
-      }
-    } catch (err) {
-      childLogger(tradeLogger, 'Price').warn("Moralis fallback failed", { address });
-    }
-
-    // Final: return a shaped object to avoid spread errors upstream
+    // Shaped return to avoid spread errors if price lookup fails
     return { usdPrice: undefined as unknown as number } as any;
 }
+
+// Bitquery support removed; Moralis is the sole price provider
 
 export const convertAsSignal = async (histories: any, solana = false) => {
     try {
@@ -145,10 +76,11 @@ export const convertAsSignal = async (histories: any, solana = false) => {
         let priceResult = []
      
         for (let i = 0; i < uniqueData.length; i++) {
+            const priceData = await getSolanaTokenPrice(uniqueData[i].address);
             priceResult[i] = {
-                ...await getSolanaTokenPriceBitquery(uniqueData[i].address),
+                usdPrice: (priceData as any)?.usdPrice,
                 tokenAddress: uniqueData[i].address
-            }
+            };
         }
         priceResult.forEach(e => {
             childLogger(tradeLogger, 'Signals').debug("token price", { tokenAddress: e.tokenAddress.toString().toLowerCase(), usdPrice: e.usdPrice });

--- a/test.env_example.2.txt.txt
+++ b/test.env_example.2.txt.txt
@@ -7,5 +7,3 @@ WEBSOCKET_URL = "wss://mainnet.helius-rpc.com/?api-key=your keys here "
 
 FALCONHIT_API_KEY="..."
 MORALIS_API_KEY="your key here"
-BITQUERY_V2_TOKEN="..."
-BITQUERY_V1_TOKEN="..."


### PR DESCRIPTION
## Summary
- drop Bitquery configuration and API usage
- fetch Solana token prices exclusively via Moralis
- clean up environment template and docs

## Testing
- `yarn build`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b899a77a2c8325a41bcb478cc66f96